### PR TITLE
add: ガチャ機能のAPIとルートを実装

### DIFF
--- a/back/src/gacha/gachaController.ts
+++ b/back/src/gacha/gachaController.ts
@@ -1,0 +1,23 @@
+import express, { Request, Response } from 'express';
+import * as gachaService from './gachaService';
+
+const router = express.Router();
+
+router.post("/", async (req: Request, res: Response) => {
+    const token = req.headers.authorization?.split('Bearer ')[1];
+
+    if (!token) {
+        return res.status(400).json({ message: 'tokenがありません'});
+    }
+
+    try {
+        const result = await gachaService.gachapon(token);
+        res.status(200).json({ message: "ガチャポンAPIが正しく動作しました", result })
+    } catch (error) {
+        res.status(500).json({ message: "ガチャポンAPIが正しく動作しませんでした" });
+        console.log( error );
+    }
+
+})
+
+export default router;

--- a/back/src/gacha/gachaService.ts
+++ b/back/src/gacha/gachaService.ts
@@ -1,0 +1,71 @@
+import { FieldValue, Timestamp, } from "firebase-admin/firestore";
+import { db, auth } from "../firebase/firebase";
+
+export const gachapon = async (token: string) => {
+    const decoded = await auth.verifyIdToken(token);
+    const uid = decoded.uid;
+
+    const doc = await db.collection('users').doc(uid).get();
+    
+    const gachaAt = doc.get("gacha_at")?.toDate();
+    const now = new Date();
+
+    if ( gachaAt ) {
+        const ms = now.getTime() - gachaAt.getTime();
+        const hours = ms /  (1000 * 60 * 60);
+
+        if (hours < 24) {
+            const remainingTime = Math.ceil(24 - hours)
+            return { message: `あと${remainingTime}時間後にガチャを引けます`};
+        }
+
+        const storedb = db.collection("stores");
+        const stores = await storedb.get();
+
+        const storeArray = stores.docs.map(doc => doc.id);
+
+        const store_id = storeArray[Math.floor(Math.random() * storeArray.length)];
+
+        const percent = await db.collection("stores").doc(store_id).get();
+        const storePercent = percent.data()?.percent;
+
+
+        const rand = Math.random() * 100; 
+        let result;
+
+        if (rand < storePercent) {
+            result = "当たり"; 
+        } else {
+            result = "外れ"; 
+            return { message: "はずれ" };
+        }
+
+        const queryTickets = await db.collection("tickets")
+            .where("store_id", "==", store_id)
+            .get();
+
+        const tickets = queryTickets.docs.map(doc => doc.id);
+
+        const selectTicket = tickets[ Math.floor( Math.random() * tickets.length ) ];
+
+        const Ticket = await db.collection("tickets").doc(selectTicket).get();
+        const TicketInfo:any = Ticket.data();
+
+        
+        const createUserTicket: any = await db.collection("userTicket").add({
+            store_id: store_id,
+            prize: TicketInfo.prize,
+            expiration_at: Timestamp.fromDate( new Date( TicketInfo.expiration_at )),
+            effective: true
+        });
+
+        const userTicket_id = createUserTicket.id;
+
+        await db.collection("users").doc(uid).update({
+            gacha_at: Timestamp.fromDate(now),
+            tickets: FieldValue.arrayUnion(createUserTicket.id)
+        });
+
+        return { result, userTicket_id: TicketInfo.prize, store_id };
+    };
+}

--- a/back/src/routes.ts
+++ b/back/src/routes.ts
@@ -21,5 +21,9 @@ router.use('/ticket', ticketRoutes);
 import announceRoutes from './announce/announceController';
 router.use('/announce', announceRoutes);
 
+//gachaルートインポート
+import gachaRoutes from './gacha/gachaController';
+router.use('/gacha', gachaRoutes);
+
 
 export default router;

--- a/back/src/user/userService.ts
+++ b/back/src/user/userService.ts
@@ -1,5 +1,5 @@
 import { db, auth } from "../firebase/firebase";
-import { FieldValue } from "firebase-admin/firestore";
+import { FieldValue, Timestamp } from "firebase-admin/firestore";
 
 export const createUser = async ( Token: string ) => {
     const decoded = await auth.verifyIdToken(Token);
@@ -10,12 +10,18 @@ export const createUser = async ( Token: string ) => {
     const userRef = db.collection("users").doc(uid);
     const userSnap = await userRef.get();
 
+    const now = new Date();
+
+    // 25時間前
+    const gachaAt = new Date(now.getTime() - 25 * 60 * 60 * 1000);
+
     if (!userSnap.exists) {
         await userRef.set({
             name,
             create_at: FieldValue.serverTimestamp(),
             update_at: FieldValue.serverTimestamp(),
             tickets: [],
+            gacha_at: Timestamp.fromDate(gachaAt),
         });
         return { message: "新規登録完了"};
     } else {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an authenticated gacha endpoint to draw once every 24 hours.
  * Returns clear results (hit/miss); on hit, issues a store-specific ticket with an expiration date.
  * New users are initialized so they can draw immediately on first signup.

* **Bug Fixes**
  * Improved error handling and responses for missing or invalid authentication during gacha draws.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->