### PR TITLE
add: アナウンス作成APIにトークン認証を追加し、タグ作成APIにトークンチェックを実装

### DIFF
--- a/back/src/announce/announceController.ts
+++ b/back/src/announce/announceController.ts
@@ -5,6 +5,12 @@ const router = express.Router();
 
 //アナウンス作成
 router.post("/", async (req:Request, res:Response) => {
+    const token = req.headers.authorization?.split('Bearer ')[1];
+
+    if (!token) {
+        return res.status(400).json({ message: 'tokenがありません'});
+    }
+
     try {
         const { announceName,announceSummary,event_at} = req.body || {};
         if (!announceName) {
@@ -16,10 +22,20 @@ router.post("/", async (req:Request, res:Response) => {
         if (!event_at) {
             return res.status(400).json({ message: "開催時刻が有りません" })
         }
-        await announceService.createAnnounce(announceName,announceSummary,event_at); 
+        await announceService.createAnnounce(announceName,announceSummary,event_at,token); 
         res.status(200).json({ message: "お知らせ作成API成功"});
     } catch (error) {
         res.status(500).json({ message: "お知らせ作成APIエラー" });
+        console.log(error);
+    }
+})
+
+router.get("/", async (req: Request, res: Response) => {
+    try {
+        const result = await announceService.getAnnounce(); 
+        res.status(200).json({ message: "お知らせ作成API成功", result});        
+    } catch (error) {
+        res.status(500).json({ message: "お知らせ取得APIエラー" });
         console.log(error);
     }
 })

--- a/back/src/announce/announceService.ts
+++ b/back/src/announce/announceService.ts
@@ -1,9 +1,17 @@
-import { title } from "process";
-import { db, auth } from "../firebase/firebase";
+import { db, } from "../firebase/firebase";
 import { firestore } from "firebase-admin";
 import { Timestamp } from "firebase-admin/firestore";
+import jwt from "jsonwebtoken";
 
-export const createAnnounce = async (announceName:string,announceSummary:number,event_at:string) => {
+export const createAnnounce = async (announceName:string,announceSummary:number,event_at:string, token: string) => {
+
+    const decoded = jwt.verify(token, process.env.JWT_SECRET!) as { id: string; email: string };
+    const email = decoded.id;
+
+    if ( email !== "ishibashi@gmail.com" ) {
+        return ({ message: "お知らせを作成する権限がありません"});
+    }
+
     //title,summaryが来た時点で自動作成
     //event_at(string)をDateに変換してタイムスタンプに
     const time_now = firestore.Timestamp.now();
@@ -14,4 +22,8 @@ export const createAnnounce = async (announceName:string,announceSummary:number,
         event_at: Timestamp.fromDate(new Date(event_at)),
         updated_at: time_now,
     });    
+}
+
+export const getAnnounce = async () => {
+    return
 }

--- a/back/src/store/storeController.ts
+++ b/back/src/store/storeController.ts
@@ -63,7 +63,7 @@ router.patch("/", async (req: Request, res: Response) => {
         return res.status(401).json({ message: "Authorization ヘッダーがありません" });
     };
 
-    const token = authHeader.split(" ")[0];
+    const token = authHeader.split(" ")[1];
     if (!token) {
         return res.status(401).json({ message: "トークンが見つかりません" });
     };

--- a/back/src/tag/tagController.ts
+++ b/back/src/tag/tagController.ts
@@ -6,6 +6,12 @@ const router = express.Router();
 //タグ作成API
 router.post("/", async (req:Request, res:Response) => {
     try {
+        const token = req.headers.authorization?.split('Bearer ')[1];
+        
+        if (!token) {
+            return res.status(400).json({ message: 'tokenがありません'});
+        }
+
         const { tagName,tagId } = req.body || {};
         if (!tagName ) {
             return res.status(400).json({ message: "タグの名前が有りません" })
@@ -13,7 +19,7 @@ router.post("/", async (req:Request, res:Response) => {
         if (!tagId) {
             return res.status(400).json({ message: "IDが有りません" })
         }
-        await tagService.createTag(tagName,tagId); 
+        await tagService.createTag(tagName,tagId,); 
         res.status(200).json({ message: "タグ作成API成功"});
     } catch (error) {
         res.status(500).json({ message: "タグ作成APIエラー" });

--- a/back/src/tag/tagService.ts
+++ b/back/src/tag/tagService.ts
@@ -1,6 +1,7 @@
-import { db, auth } from "../firebase/firebase";
+import { db } from "../firebase/firebase";
+import jwt from "jsonwebtoken";
 
-export const createTag = async (tagName:string,tagId:number) => {
+export const createTag = async (tagName:string,tagId:number,) => {
     //firebaseのtagsにタグを追加
     await db.collection('tags').add({
         name: tagName,
@@ -10,7 +11,6 @@ export const createTag = async (tagName:string,tagId:number) => {
 
 export const getTag = async () => {
     //firebaseのtagsのタグを収集
-    
     const tagAll = await db.collection('tags').get();
 
     if(tagAll.empty){


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added GET endpoint to retrieve announcements.
  - Announcement creation now requires a Bearer token and enforces permission checks, returning an authorization error if the user is not allowed.

- Bug Fixes
  - Corrected Bearer token parsing in the store update endpoint to reliably read tokens from the Authorization header.
  - Tag creation endpoint now validates the presence of a Bearer token and returns a 400 error if missing.

- Chores
  - Improved error logging in tag creation for easier troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->