### PR TITLE
動作確認済み お知らせの取得

### DIFF
--- a/back/src/announce/announceController.ts
+++ b/back/src/announce/announceController.ts
@@ -33,11 +33,10 @@ router.post("/", async (req:Request, res:Response) => {
 router.get("/", async (req: Request, res: Response) => {
     try {
         const result = await announceService.getAnnounce(); 
-        res.status(200).json({ message: "お知らせ作成API成功", result});        
+        res.status(200).json({ message: "お知らせ取得成功", result});        
     } catch (error) {
         res.status(500).json({ message: "お知らせ取得APIエラー" });
         console.log(error);
     }
 })
-
 export default router;

--- a/back/src/announce/announceService.ts
+++ b/back/src/announce/announceService.ts
@@ -18,12 +18,28 @@ export const createAnnounce = async (announceName:string,announceSummary:number,
     await db.collection('announcement').add({
         title: announceName,
         summary: announceSummary,
-        created_at: time_now,
         event_at: Timestamp.fromDate(new Date(event_at)),
+        created_at: time_now,
         updated_at: time_now,
     });    
 }
 
 export const getAnnounce = async () => {
-    return
+    //firebaseのannouncementのお知らせを収集
+    const announceAll = await db.collection('announcement').get();
+    if(announceAll.empty){
+        return[];
+    }
+    const result:any = [];
+    announceAll.forEach(doc => {
+        result.push({
+            title: doc.data().title,
+            summary: doc.data().summary,
+            event_at: doc.data().event_at,
+            created_at: doc.data().created_at,
+            updated_at: doc.data().updated_at,
+        //他のがあれば追加
+        });
+    });
+    return result;
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Announcement retrieval API now returns a list of announcements, including title, summary, event_at, created_at, and updated_at. Returns an empty list when none are available.

* **Bug Fixes**
  * Updated GET announcements success message to “お知らせ取得成功” while retaining the same payload and HTTP 200 status. Error handling unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->