### PR TITLE
fix: mapをticketにリネーム

### DIFF
--- a/frontend/lib/app/router.dart
+++ b/frontend/lib/app/router.dart
@@ -4,7 +4,7 @@ import '../auth.dart';
 
 import '../component/ui/navbar/navbar.dart';
 import '../protected/top/index.dart';
-import '../protected/map/index.dart';
+import '../protected/ticket/index.dart';
 import '../protected/settings/index.dart';
 import '../login/general_login.dart';
 
@@ -24,7 +24,7 @@ final appRouter = GoRouter(
       builder: (context, state, child) => _RootShell(child: child),
       routes: [
         GoRoute(path: '/', builder: (_, __) => const TopPage()),
-        GoRoute(path: '/map', builder: (_, __) => const MapPage()),
+        GoRoute(path: '/ticket', builder: (_, __) => const TicketPage()),
         GoRoute(path: '/settings', builder: (_, __) => const SettingPage()),
       ],
     ),
@@ -37,7 +37,7 @@ class _RootShell extends StatelessWidget {
 
   int _indexFromLocation(BuildContext context) {
     final loc = GoRouterState.of(context).uri.toString();
-    if (loc.startsWith('/map')) return 0;
+    if (loc.startsWith('/ticket')) return 0;
     if (loc.startsWith('/settings')) return 2;
     return 1;
   }
@@ -45,7 +45,7 @@ class _RootShell extends StatelessWidget {
   void _onTap(BuildContext context, int i) {
     switch (i) {
       case 0:
-        context.go('/map');
+        context.go('/ticket');
         break;
       case 1:
         context.go('/');

--- a/frontend/lib/protected/ticket/index.dart
+++ b/frontend/lib/protected/ticket/index.dart
@@ -1,13 +1,13 @@
 import 'package:flutter/material.dart';
 import 'layout.dart';
 
-class MapPage extends StatelessWidget {
-  const MapPage({super.key});
+class TicketPage extends StatelessWidget {
+  const TicketPage({super.key});
 
   @override
   Widget build(BuildContext context) {
     return Container(
-      color: MapLayout.bgColor,
+      color: TicketLayout.bgColor,
 
     );
   }

--- a/frontend/lib/protected/ticket/layout.dart
+++ b/frontend/lib/protected/ticket/layout.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 
-class MapLayout {
+class TicketLayout {
   static const bgColor = Color(0xFF006AFF);
   static const double pad = 16.0;
 }


### PR DESCRIPTION
close #67 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Replaced the “Map” page with “Ticket” across the app.
  - Updated the primary route from /map to /ticket; navigation tabs, redirects, and deep links now target /ticket.
  - Adjusted tab indexing and on-tap behavior to open the Ticket page.

- Style
  - Updated the Ticket page background color to match the new layout theme.

Note: If you had bookmarks or links to /map, they now direct to /ticket.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->