### PR TITLE
add: 所持チケのボタンでチケット画面に遷移

### DIFF
--- a/frontend/lib/protected/top/_component/itemButton/item_button.dart
+++ b/frontend/lib/protected/top/_component/itemButton/item_button.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 import 'item_button_style.dart';
 import 'round_button.dart';
+
 class _ButtonItem extends StatelessWidget {
   const _ButtonItem({
     required this.text,
@@ -33,10 +35,7 @@ class ItemButton extends StatelessWidget {
     return Align(
       alignment: Alignment.centerRight,
       child: Container(
-        padding: const EdgeInsets.only(
-        right: 7.0,
-        bottom: 450,
-      ),
+        padding: const EdgeInsets.only(right: 7.0, bottom: 450),
         child: Column(
           mainAxisAlignment: MainAxisAlignment.end,
           children: [
@@ -49,7 +48,7 @@ class ItemButton extends StatelessWidget {
             _ButtonItem(
               text: '所持チケ',
               iconAsset: ItemButtonStyle.ellipsesIcon,
-              onPressed: () => print('所持チケを押したよ！'),
+              onPressed: () => context.go('/ticket'), 
             ),
           ],
         ),
@@ -57,3 +56,4 @@ class ItemButton extends StatelessWidget {
     );
   }
 }
+


### PR DESCRIPTION
close #76 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tapping the “所持チケ” (Tickets) item now navigates directly to the Ticket screen from the top menu, improving access to your tickets.

* **Refactor**
  * Minor formatting cleanup with no impact on behavior or appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->