### PR TITLE
feat: バックエンドにJWTを使用して新しいリクエストを送信する処理を追加

### DIFF
--- a/frontend/lib/auth.dart
+++ b/frontend/lib/auth.dart
@@ -45,6 +45,15 @@ Future<bool> sendIdTokenToBackend() async {
       await prefs.setString('jwt', jwt);
 
       print('バックエンドJWT取得成功: $jwt');
+
+      final res = await http.post(
+        Uri.parse('https://${Env.apiBaseUrl}/user/'),
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': 'Bearer $jwt', // ← こっちにJWTをのせる
+          },
+      );
+
       return true;
     } else {
       print('バックエンド認証失敗: ${response.body}');


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - During successful sign-in, the app now performs an additional background request using the stored token.
  - This request runs silently in the background and does not change the sign-in flow or on-screen behavior.
  - Success and error handling remain unchanged; users should experience the same login outcome and timing as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->