### PR TITLE
fix: TicketDtoのJSONパース時にprizeの型を修正し、緯度経度の取得方法を更新

### DIFF
--- a/frontend/lib/api/dto/ticket_dto.dart
+++ b/frontend/lib/api/dto/ticket_dto.dart
@@ -14,12 +14,13 @@ class TicketDto {
   });
 
   factory TicketDto.fromJson(Map<String, dynamic> j) => TicketDto(
-    prize: j['prize'] as String,
+    prize: j['prize'] as String? ?? '',
     expirationAt: j['expiration_at']?.toString() ?? '',
     storeName: j['store_name'] as String? ?? '',
-    latitude: (j['_latitude'] as num?)?.toDouble() ?? 0.0,
-    longitude: (j['_longitude'] as num?)?.toDouble() ?? 0.0,
+    latitude: (j['point']?['lat'] as num?)?.toDouble() ?? 0.0,
+    longitude: (j['point']?['lng'] as num?)?.toDouble() ?? 0.0,
   );
+
 }
 
 class TicketsResponse {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of missing prize information to avoid errors; empty values are now safely displayed.
  * Corrected location parsing for tickets to use the proper latitude/longitude fields, improving map pin accuracy and distance calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->